### PR TITLE
Touchups while reviewing code

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -13,7 +13,7 @@ func getFileName(f *os.File) (string, error) {
 	fd := f.Fd()
 	name, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), fd))
 	if err != nil {
-		return "", fmt.Errorf("tail: fail to get path of fd: %d", fd)
+		return "", fmt.Errorf("getting path of file descriptor %d: %w", fd, err)
 	}
 	return name, nil
 }

--- a/fs_darwin.go
+++ b/fs_darwin.go
@@ -34,7 +34,7 @@ func getFileName(f *os.File) (string, error) {
 
 	idx := bytes.IndexByte(buf[:], 0)
 	if idx < 0 {
-		return "", fmt.Errorf("tail: fail to get path of fd: %d", fd)
+		return "", fmt.Errorf("getting path of file descriptor %d", fd)
 	}
 	return string(buf[:idx]), nil
 }

--- a/tail.go
+++ b/tail.go
@@ -271,10 +271,10 @@ func (t *tail) runFile() {
 		case err := <-cherr:
 			if errors.Is(err, io.EOF) {
 				waiting = true
-			} else {
+				continue
+			}
 			t.parent.errors <- err
 			return
-			}
 		case err := <-t.watcher.Errors:
 			t.parent.errors <- err
 			return

--- a/tail_test.go
+++ b/tail_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,11 +36,8 @@ var Logs = []string{
 }
 
 func TestTailFile(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "go-tail.")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(tmpdir)
+	t.Parallel()
+	tmpdir := t.TempDir()
 
 	go writeFile(t, tmpdir)
 	tail, err := NewTailFile(filepath.Join(tmpdir, "test.log"))
@@ -61,6 +57,7 @@ func TestTailFile(t *testing.T) {
 }
 
 func TestTailReader(t *testing.T) {
+	t.Parallel()
 	reader, writer := io.Pipe()
 
 	go writeWriter(t, writer)
@@ -100,6 +97,7 @@ func TestTailReader(t *testing.T) {
 }
 
 func TestTailReader_Close(t *testing.T) {
+	t.Parallel()
 	reader, writer := io.Pipe()
 	defer reader.Close()
 	defer writer.Close()
@@ -120,7 +118,7 @@ func TestTailReader_Close(t *testing.T) {
 
 func writeFile(t *testing.T, tmpdir string) error {
 	filename := filepath.Join(tmpdir, "test.log")
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
@@ -146,7 +144,7 @@ func writeFile(t *testing.T, tmpdir string) error {
 			if err := os.Rename(filename, filename+".old"); err != nil {
 				return err
 			}
-			file, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+			file, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o644)
 			if err != nil {
 				return err
 			}
@@ -211,11 +209,8 @@ func receive(t *testing.T, tail *Tail) (string, error) {
 }
 
 func TestTailFile_Rotate(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "go-tail.")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(tmpdir)
+	t.Parallel()
+	tmpdir := t.TempDir()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -224,7 +219,7 @@ func TestTailFile_Rotate(t *testing.T) {
 		filename := filepath.Join(tmpdir, "test.log")
 		for i := 0; i < 10; i++ {
 			i := i
-			file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+			file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o644)
 			if err != nil {
 				t.Error(err)
 				return

--- a/tail_test.go
+++ b/tail_test.go
@@ -82,7 +82,7 @@ func TestTailReader(t *testing.T) {
 		if ok {
 			t.Error("want closed, but not")
 		}
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		t.Error("want closed, but not")
 	}
 	select {
@@ -90,7 +90,7 @@ func TestTailReader(t *testing.T) {
 		if ok {
 			t.Error("want closed, but not")
 		}
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		t.Error("want closed, but not")
 	}
 	tail.Close()
@@ -124,7 +124,7 @@ func writeFile(t *testing.T, tmpdir string) error {
 	}
 
 	// wait for starting to tail...
-	time.Sleep(2 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 
 	for _, line := range Logs {
 		_, err := file.WriteString(line)
@@ -149,7 +149,7 @@ func writeFile(t *testing.T, tmpdir string) error {
 				return err
 			}
 		case TruncateMarker:
-			time.Sleep(1 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 			if _, err := file.Seek(0, io.SeekStart); err != nil {
 				return err
 			}
@@ -157,7 +157,7 @@ func writeFile(t *testing.T, tmpdir string) error {
 				return err
 			}
 		}
-		time.Sleep(90 * time.Millisecond)
+		time.Sleep(9 * time.Millisecond)
 	}
 
 	if err := file.Close(); err != nil {
@@ -181,7 +181,7 @@ func writeWriter(t *testing.T, writer io.Writer) error {
 		} else {
 			t.Logf("write: %s...(snip)", line[:100])
 		}
-		time.Sleep(90 * time.Millisecond)
+		time.Sleep(9 * time.Millisecond)
 	}
 	return nil
 }
@@ -202,7 +202,7 @@ func receive(t *testing.T, tail *Tail) (string, error) {
 			}
 		case err := <-tail.Errors:
 			return "", err
-		case <-time.After(5 * time.Second):
+		case <-time.After(500 * time.Millisecond):
 			return "", errors.New("timeout")
 		}
 	}
@@ -226,7 +226,7 @@ func TestTailFile_Rotate(t *testing.T) {
 			}
 			if i == 0 {
 				// wait for starting to tail...
-				time.Sleep(2 * time.Second)
+				time.Sleep(200 * time.Millisecond)
 			}
 
 			// start to write logs
@@ -235,7 +235,7 @@ func TestTailFile_Rotate(t *testing.T) {
 				defer wg.Done()
 				writeFileAndClose(t, file, fmt.Sprintf("file: %d\n", i))
 			}()
-			time.Sleep(time.Second)
+			time.Sleep(100 * time.Millisecond)
 
 			// Rotate log file, and start writing logs into a new file.
 			// While, some logs are still written into the old file.
@@ -276,7 +276,7 @@ func writeFileAndClose(t *testing.T, file *os.File, line string) {
 			t.Error(err)
 			return
 		}
-		time.Sleep(90 * time.Millisecond)
+		time.Sleep(9 * time.Millisecond)
 	}
 
 	if err := file.Close(); err != nil {

--- a/tail_test.go
+++ b/tail_test.go
@@ -213,6 +213,7 @@ func TestTailFile_Rotate(t *testing.T) {
 	tmpdir := t.TempDir()
 
 	var wg sync.WaitGroup
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
Context cancellation could come from anywhere, it masks external cancellation signal as nil err.

Tests shouldn't depend on time.Sleep, rather tracking something happens before something else. Right now, a race could happen, where all writers complete before tailing starts.

Don't wrap errors of no meaningful content. Most stdlib errors already contain relevant info. For example `"failed to open file: %w"` will result in `failed to open file: failed to open file xyz.txt due to bla`.