### PR TITLE
use io.SeekEnd instead of os.SEEK_END

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -81,7 +81,7 @@ func NewTailFileWithOptions(filename string, opts Options) (*Tail, error) {
 	}
 
 	parent.wg.Go(func() {
-		parent.runFile(os.SEEK_END)
+		parent.runFile(io.SeekEnd)
 	})
 	go parent.wait()
 


### PR DESCRIPTION
`os.SEEK_END` is deprecated from Go 1.17.
we should use `io.SeekEnd` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal improvements to file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->